### PR TITLE
feature: add select query

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     implementation 'ch.qos.logback:logback-classic:1.4.7'
     implementation 'com.h2database:h2:2.1.214'
+    implementation 'com.google.guava:guava:33.0.0-jre'
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/src/main/java/hibernate/sql/Dialect.java
+++ b/src/main/java/hibernate/sql/Dialect.java
@@ -1,0 +1,4 @@
+package hibernate.sql;
+
+interface Dialect {
+}

--- a/src/main/java/hibernate/sql/EqualsRestriction.java
+++ b/src/main/java/hibernate/sql/EqualsRestriction.java
@@ -1,0 +1,22 @@
+package hibernate.sql;
+
+/**
+ * SQL query 조건문에서 일치하는 조건을 나타내는 클래스
+ */
+public class EqualsRestriction implements Restriction {
+
+    private static final String EQUALS_OPERATOR = "=";
+
+    private final String column;
+    private final String value;
+
+    public EqualsRestriction(String column, String value) {
+        this.column = column;
+        this.value = value;
+    }
+
+    @Override
+    public String render() {
+        return column + EQUALS_OPERATOR + value;
+    }
+}

--- a/src/main/java/hibernate/sql/MySqlDialect.java
+++ b/src/main/java/hibernate/sql/MySqlDialect.java
@@ -1,0 +1,4 @@
+package hibernate.sql;
+
+public class MySqlDialect implements Dialect {
+}

--- a/src/main/java/hibernate/sql/Restriction.java
+++ b/src/main/java/hibernate/sql/Restriction.java
@@ -2,6 +2,8 @@ package hibernate.sql;
 
 /**
  * SQL query 조건문을 나타내는 인터페이스
+ *
+ * @see org.hibernate.sql.Restriction
  */
 public interface Restriction {
 

--- a/src/main/java/hibernate/sql/Restriction.java
+++ b/src/main/java/hibernate/sql/Restriction.java
@@ -1,0 +1,9 @@
+package hibernate.sql;
+
+/**
+ * SQL query 조건문을 나타내는 인터페이스
+ */
+public interface Restriction {
+
+    String render();
+}

--- a/src/main/java/hibernate/sql/Select.java
+++ b/src/main/java/hibernate/sql/Select.java
@@ -8,6 +8,9 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * @see org.hibernate.sql.SimpleSelect
+ */
 public class Select {
     private final String tableName;
     private final List<String> columns;

--- a/src/main/java/hibernate/sql/Select.java
+++ b/src/main/java/hibernate/sql/Select.java
@@ -1,0 +1,117 @@
+package hibernate.sql;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class Select {
+    private final String tableName;
+    private final List<String> columns;
+    private final Map<String, String> columnAliases;
+    private final List<Restriction> restrictions;
+
+    private final Dialect dialect;
+
+    private Select(String tableName,
+                   List<String> columns,
+                   Map<String, String> columnAliases,
+                   List<Restriction> restrictions,
+                   Dialect dialect) {
+        checkNotNull(tableName, "tableName must not be null");
+        checkNotNull(dialect, "dialect must not be null");
+        this.tableName = tableName;
+        this.columns = columns;
+        this.columnAliases = columnAliases;
+        this.restrictions = restrictions;
+        this.dialect = dialect;
+    }
+
+    public String toQuery() {
+        StringBuilder sqlBuffer = new StringBuilder(
+                tableName.length() +
+                        columns.size() * 10 +
+                        restrictions.size() * 10 +
+                        10
+        );
+
+        applySelectClause(sqlBuffer);
+        applyFromClause(sqlBuffer);
+        applyWhereClause(sqlBuffer);
+
+        return sqlBuffer.append(";").toString();
+    }
+
+    private void applySelectClause(StringBuilder sqlBuffer) {
+        sqlBuffer.append("select ").append(parseColumns());
+    }
+
+    private String parseColumns() {
+        return columns.stream()
+                .map(this::parseColumn)
+                .collect(Collectors.joining(", "));
+    }
+
+    private String parseColumn(String column) {
+        String tableColumn = String.format("%s.%s", tableName, column);
+        String alias = columnAliases.get(column);
+        if (alias == null) {
+            return tableColumn;
+        }
+        return String.format("%s as %s", tableColumn, alias);
+    }
+
+    private void applyFromClause(StringBuilder sqlBuffer) {
+        sqlBuffer.append(" from ").append(tableName);
+    }
+
+    private void applyWhereClause(StringBuilder sqlBuffer) {
+        sqlBuffer.append(" where ").append(parseRestriction());
+    }
+
+    private String parseRestriction() {
+        return restrictions.stream()
+                .map(Restriction::render)
+                .collect(Collectors.joining(" and "));
+    }
+
+    public static class Builder {
+        private String tableName;
+        private List<String> columns = new ArrayList<>();
+        private Map<String, String> columnAliases = new HashMap<>();
+        private List<Restriction> restrictions = new ArrayList<>();
+        private Dialect dialect;
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder columns(List<String> columns) {
+            this.columns = columns;
+            return this;
+        }
+
+        public Builder columnAliases(Map<String, String> columnAliases) {
+            this.columnAliases = columnAliases;
+            return this;
+        }
+
+        public Builder restrictions(List<Restriction> restrictions) {
+            this.restrictions = restrictions;
+            return this;
+        }
+
+        public Builder dialect(Dialect dialect) {
+            this.dialect = dialect;
+            return this;
+        }
+
+        public Select build() {
+            return new Select(tableName, columns, columnAliases, restrictions, dialect);
+        }
+    }
+}

--- a/src/main/java/hibernate/sql/Select.java
+++ b/src/main/java/hibernate/sql/Select.java
@@ -49,7 +49,8 @@ public class Select {
     }
 
     private void applySelectClause(StringBuilder sqlBuffer) {
-        sqlBuffer.append("select ").append(parseColumns());
+        sqlBuffer.append("select ")
+                .append(parseColumns());
     }
 
     private String parseColumns() {
@@ -68,11 +69,13 @@ public class Select {
     }
 
     private void applyFromClause(StringBuilder sqlBuffer) {
-        sqlBuffer.append(" from ").append(tableName);
+        sqlBuffer.append(" from ")
+                .append(tableName);
     }
 
     private void applyWhereClause(StringBuilder sqlBuffer) {
-        sqlBuffer.append(" where ").append(parseRestriction());
+        sqlBuffer.append(" where ")
+                .append(parseRestriction());
     }
 
     private String parseRestriction() {

--- a/src/test/java/hibernate/sql/EqualsRestrictionTest.java
+++ b/src/test/java/hibernate/sql/EqualsRestrictionTest.java
@@ -1,0 +1,18 @@
+package hibernate.sql;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EqualsRestrictionTest {
+
+    @Nested
+    class render {
+        @Test
+        void 컬럼명과_값이_주어지면_쿼리_조건을_반환한다() {
+            String actual = new EqualsRestriction("name", "huni").render();
+            assertThat(actual).isEqualTo("name=huni");
+        }
+    }
+}

--- a/src/test/java/hibernate/sql/SelectTest.java
+++ b/src/test/java/hibernate/sql/SelectTest.java
@@ -1,0 +1,89 @@
+package hibernate.sql;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelectTest {
+
+    @Nested
+    class init {
+        @Test
+        void tableName이_null이면_예외가_발생한다() {
+            NullPointerException actual = assertThrows(NullPointerException.class, () -> new Select.Builder()
+                    .tableName(null)
+                    .dialect(new MySqlDialect())
+                    .build());
+            assertThat(actual).hasMessage("tableName must not be null");
+        }
+
+        @Test
+        void dialect가_null이면_예외가_발생한다() {
+            NullPointerException actual = assertThrows(NullPointerException.class, () -> new Select.Builder()
+                    .tableName("tableName")
+                    .dialect(null)
+                    .build());
+            assertThat(actual).hasMessage("dialect must not be null");
+        }
+    }
+
+    @Nested
+    class toQuery {
+        @Test
+        void 조건이_단순한_select문을_생성한다() {
+            // given
+            Select select = new Select.Builder()
+                    .tableName("member")
+                    .columns(List.of("id", "name", "age"))
+                    .restrictions(List.of(new EqualsRestriction("id", "1")))
+                    .dialect(new MySqlDialect())
+                    .build();
+
+            // when
+            String actual = select.toQuery();
+
+            // then
+            assertThat(actual).isEqualTo("select member.id, member.name, member.age from member where id=1;");
+        }
+
+        @Test
+        void column의_alias가_있는_경우_추가된_select문을_생성한다() {
+            // given
+            Select select = new Select.Builder()
+                    .tableName("member")
+                    .columns(List.of("id", "name", "age"))
+                    .columnAliases(Map.of("id", "id"))
+                    .restrictions(List.of(new EqualsRestriction("id", "1")))
+                    .dialect(new MySqlDialect())
+                    .build();
+
+            // when
+            String actual = select.toQuery();
+
+            // then
+            assertThat(actual).isEqualTo("select member.id as id, member.name, member.age from member where id=1;");
+        }
+
+        @Test
+        void where조건문이_있는_경우_and가_추가된_select문을_생성한다() {
+            // given
+            Select select = new Select.Builder()
+                    .tableName("member")
+                    .columns(List.of("id", "name", "age"))
+                    .restrictions(List.of(new EqualsRestriction("id", "1"), new EqualsRestriction("age", "20")))
+                    .dialect(new MySqlDialect())
+                    .build();
+
+            // when
+            String actual = select.toQuery();
+
+            // then
+            assertThat(actual).isEqualTo("select member.id, member.name, member.age from member where id=1 and age=20;");
+        }
+    }
+}


### PR DESCRIPTION
- 객체지향이 없는 코드더라도 최대한 하이버네이트의 구현 내용을 따라가는 것이 목표
    - 예를 들면, `Select`는 `@Entity` 정보를 가지고 있는 상태에서 필요에 따라 쿼리를 동기적으로 생성하도록 설계할 수 있음 (Entity당 Select는 한개로)
    - 하지면 하이버네이트는 Select쿼리를 생성할 때마다 만들고 있어 `Select`는 추출한 값을 그대로 가지고 `Class` 리플랙션 정보에 대한 값을 없도록 의도함 (org.hibernate.sql.SimpleSelect)